### PR TITLE
6 is testing doubting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ endif ()
 
 add_executable(clings main.c
         src/clings.c
-        src/execution/execution.c
         src/result_handler/result_handler.c
 )
 target_include_directories(clings PUBLIC src)
@@ -21,6 +20,7 @@ add_subdirectory(src/configuration)
 target_link_libraries(clings PUBLIC configuration)
 enable_testing()
 
+
 add_subdirectory(src/types)
 target_link_libraries(clings PUBLIC types)
 target_link_libraries(sized_string_test PUBLIC test_utils)
@@ -29,7 +29,13 @@ add_subdirectory(src/katas)
 target_link_libraries(clings PUBLIC katas)
 target_link_libraries(katas PUBLIC types)
 target_link_libraries(katas_test PUBLIC test_utils)
-target_link_libraries(katas_test PUBLIC types)
+target_link_libraries(katas_test PUBLIC katas)
 
+add_subdirectory(src/execution)
+target_link_libraries(clings PUBLIC execution)
+target_link_libraries(execution PUBLIC katas)
+target_link_libraries(execution PUBLIC types)
+target_link_libraries(execution_test PUBLIC test_utils)
+target_link_libraries(execution_test PUBLIC execution)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ project(clings C)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -pedantic -Wconversion")
 
-include_directories(src)
 add_subdirectory(src/configuration)
 
 add_executable(clings main.c
@@ -15,16 +14,21 @@ add_executable(clings main.c
         src/katas/katas.c
 )
 
+if(NOT ${CMAKE_BINARY_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
+    file(COPY katas DESTINATION ${CMAKE_BINARY_DIR})
+endif ()
+
+target_include_directories(clings PUBLIC src)
+target_link_libraries(clings PUBLIC configuration)
+
+
 enable_testing()
+add_subdirectory(src/test_utils)
 
 add_executable(sized_string_test
         src/types/sized_string_test.c
         src/types/sized_string.c
 )
+target_include_directories(sized_string_test PUBLIC src/test_utils)
+target_link_libraries(sized_string_test PUBLIC clings_test_utils)
 add_test(NAME sized_string_test COMMAND sized_string_test)
-
-if(NOT ${CMAKE_BINARY_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
-    file(COPY katas DESTINATION ${CMAKE_BINARY_DIR})
-endif ()
-
-target_link_libraries(clings PUBLIC configuration)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,7 @@ if(NOT ${CMAKE_BINARY_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
     file(COPY katas DESTINATION ${CMAKE_BINARY_DIR})
 endif ()
 
-add_executable(clings main.c
-        src/clings.c
-        src/result_handler/result_handler.c
-)
+add_executable(clings main.c src/clings.c)
 target_include_directories(clings PUBLIC src)
 add_subdirectory(src/test_utils)
 
@@ -38,4 +35,6 @@ target_link_libraries(execution PUBLIC types)
 target_link_libraries(execution_test PUBLIC test_utils)
 target_link_libraries(execution_test PUBLIC execution)
 
-
+add_subdirectory(src/result_handler)
+target_link_libraries(clings PUBLIC result_handler)
+target_link_libraries(result_handler PUBLIC types)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,24 +4,32 @@ project(clings C)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -pedantic -Wconversion")
 
-add_subdirectory(src/configuration)
-add_subdirectory(src/types)
-
-add_executable(clings main.c
-        src/execution/execution.c
-        src/result_handler/result_handler.c
-        src/clings.c
-        src/katas/katas.c
-)
-
+# copy katas in build directory
 if(NOT ${CMAKE_BINARY_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
     file(COPY katas DESTINATION ${CMAKE_BINARY_DIR})
 endif ()
 
+add_executable(clings main.c
+        src/clings.c
+        src/execution/execution.c
+        src/result_handler/result_handler.c
+)
 target_include_directories(clings PUBLIC src)
-target_link_libraries(clings PUBLIC configuration)
-target_link_libraries(clings PUBLIC types)
-
-
 add_subdirectory(src/test_utils)
+
+add_subdirectory(src/configuration)
+target_link_libraries(clings PUBLIC configuration)
+enable_testing()
+
+add_subdirectory(src/types)
+target_link_libraries(clings PUBLIC types)
 target_link_libraries(sized_string_test PUBLIC test_utils)
+
+add_subdirectory(src/katas)
+target_link_libraries(clings PUBLIC katas)
+target_link_libraries(katas PUBLIC types)
+target_link_libraries(katas_test PUBLIC test_utils)
+target_link_libraries(katas_test PUBLIC types)
+
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.26)
 project(clings C)
 
 set(CMAKE_C_STANDARD 11)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -pedantic")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -pedantic -Wconversion")
 
 include_directories(src)
 add_subdirectory(src/configuration)
@@ -14,6 +14,14 @@ add_executable(clings main.c
         src/clings.c
         src/katas/katas.c
 )
+
+enable_testing()
+
+add_executable(sized_string_test
+        src/types/sized_string_test.c
+        src/types/sized_string.c
+)
+add_test(NAME sized_string_test COMMAND sized_string_test)
 
 if(NOT ${CMAKE_BINARY_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
     file(COPY katas DESTINATION ${CMAKE_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,10 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -pedantic -Wconversion")
 
 add_subdirectory(src/configuration)
+add_subdirectory(src/types)
 
 add_executable(clings main.c
         src/execution/execution.c
-        src/types/sized_string.c
         src/result_handler/result_handler.c
         src/clings.c
         src/katas/katas.c
@@ -20,15 +20,8 @@ endif ()
 
 target_include_directories(clings PUBLIC src)
 target_link_libraries(clings PUBLIC configuration)
+target_link_libraries(clings PUBLIC types)
 
 
-enable_testing()
 add_subdirectory(src/test_utils)
-
-add_executable(sized_string_test
-        src/types/sized_string_test.c
-        src/types/sized_string.c
-)
-target_include_directories(sized_string_test PUBLIC src/test_utils)
-target_link_libraries(sized_string_test PUBLIC clings_test_utils)
-add_test(NAME sized_string_test COMMAND sized_string_test)
+target_link_libraries(sized_string_test PUBLIC test_utils)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This project contains a collection of exercises to learn [C](https://en.wikipedia.org/wiki/C_(programming_language)) and is blazingly inspired by [Rustlings](https://github.com/rust-lang/rustlings).
 
+## Requirements
+* Having CMake [installed](https://cmake.org/download/)
 ## Quickstart
 
 You can build the project with the following commands:

--- a/README.md
+++ b/README.md
@@ -5,15 +5,11 @@
 This project contains a collection of exercises to learn [C](https://en.wikipedia.org/wiki/C_(programming_language)) and is blazingly inspired by [Rustlings](https://github.com/rust-lang/rustlings).
 
 ## Quickstart
-> This project uses [vcpkg](https://vcpkg.io/en/index.html) to manage dependencies. Please [install](https://vcpkg.io/en/getting-started) it before continuing. Then run `vcpkg install`.
 
 You can build the project with the following commands:
 ```bash
-cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=[path to vcpkg]/scripts/buildsystems/vcpkg.cmake
-cmake --build build
+cmake -S . -B build && cmake --build build
 ```
-> /!\ Replace `[path to vcpkg]` with the path to your vcpkg installation.
-> If you're using CLion, it's likely `~/.vcpkg-clion/vcpkg`.
 
 You can then run the project with:
 ```bash
@@ -22,22 +18,23 @@ You can then run the project with:
 
 You should see the following output:
 ```text
-Compiling katas/compilation_error.c
-katas/compilation_error.c:6:5: error: expected expression
-    return EXIT_SUCCESS;
-    ^
-1 error generated.
-Compilation failure...
+Compiling katas/00_intro/intro.c
+Success !
 
-Compilation error
+Hello !
+This exercise compiles successfully. The...
 ```
 
 IT WORKS ! You can now start coding.
 
-Update the file `katas/compilation_error.c` to make the program compile and run successfully.
-Then run the project again to check your solution.
+Update the file `katas/00_intro/intro.c` and remove the comment `// I AM NOT DONE` to pass to the next 
 ```bash
-cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=[path to vcpkg]/scripts/buildsystems/vcpkg.cmake
-cmake --build build
+cmake -S . -B build && cmake --build build
 ./build/clings
+```
+
+## Tests
+After building the project in [Quickstart](#quickstart), you can run the tests with:
+```shell
+ctest --test-dir build
 ```

--- a/katas/00_intro/intro.c
+++ b/katas/00_intro/intro.c
@@ -11,7 +11,7 @@ int main(void) {
     printf("solve the exercises. Good luck!\n");
     printf("\n");
     printf("To pass to the next kata, simply remove the comment // I AM NOT DONE at the\n");
-    printf("top of the kata file\n");
+    printf("top of the kata file.\n");
     printf("The source for this exercise is in `katas/00_intro/intro.c`. Have a look!");
 
     return EXIT_SUCCESS;

--- a/src/configuration/CMakeLists.txt
+++ b/src/configuration/CMakeLists.txt
@@ -1,7 +1,4 @@
 project(clings_configuration C)
 
-
-add_library(configuration
-        get_kata_list/in_memory_kata_list.c
-)
+add_library(configuration get_kata_list/in_memory_kata_list.c)
 target_include_directories(configuration PUBLIC ..)

--- a/src/configuration/CMakeLists.txt
+++ b/src/configuration/CMakeLists.txt
@@ -4,3 +4,4 @@ project(clings_configuration C)
 add_library(configuration
         get_kata_list/in_memory_kata_list.c
 )
+target_include_directories(configuration PUBLIC ..)

--- a/src/configuration/get_kata_list/in_memory_kata_list.c
+++ b/src/configuration/get_kata_list/in_memory_kata_list.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <string.h>
 #include "get_kata_list.h"
-#include "katas/katas.h"
 
 typedef struct kata_file {
         const char* name;

--- a/src/configuration/get_kata_list/in_memory_kata_list.c
+++ b/src/configuration/get_kata_list/in_memory_kata_list.c
@@ -20,7 +20,7 @@ const char* KATA_NOT_DONE_COMMENT = "// I AM NOT DONE";
 
 sized_string_t kata_path_from_directory_and_name(sized_string_t directory, sized_string_t kata_name);
 
-kata_t kata_of(sized_string_t name, sized_string_t directory);
+kata_t kata_from_name_and_directory(sized_string_t name, sized_string_t directory);
 
 sized_string_t c_file_name_of(sized_string_t name);
 
@@ -37,7 +37,7 @@ kata_list_fetch_result_t get_kata_list(void) {
         sized_string_t name = new_sized_string_from((char *) kata_file.name);
         sized_string_t directory = new_sized_string_from((char *) kata_file.directory);
 
-        push_kata_in_list(kata_of(name, directory), &kata_list);
+        push_kata_in_list(kata_from_name_and_directory(name, directory), &kata_list);
 
         free_sized_string(&directory);
     }
@@ -48,7 +48,7 @@ kata_list_fetch_result_t get_kata_list(void) {
     };
 }
 
-kata_t kata_of(sized_string_t name, sized_string_t directory) {
+kata_t kata_from_name_and_directory(sized_string_t name, sized_string_t directory) {
     sized_string_t path = kata_path_from_directory_and_name(directory, name);
     return (kata_t) {
             .name = name,

--- a/src/execution/CMakeLists.txt
+++ b/src/execution/CMakeLists.txt
@@ -1,0 +1,11 @@
+project(execution C)
+
+add_library(execution execution.c)
+target_include_directories(execution PUBLIC ..)
+
+add_executable(execution_test
+        execution_test.c
+        execution.c
+)
+
+add_test(NAME execution_test COMMAND execution_test)

--- a/src/execution/execution.c
+++ b/src/execution/execution.c
@@ -32,7 +32,7 @@ kata_status run_kata(const kata_t kata, sized_string_t result_buffer) {
     }
 
     // Read output to result_buffer
-    fread(result_buffer.str, (int)result_buffer.len, 1, fp);
+    fread(result_buffer.str, result_buffer.len, 1, fp);
     int status = pclose(fp);
 
     // Check execution status

--- a/src/execution/execution.h
+++ b/src/execution/execution.h
@@ -1,8 +1,8 @@
 #ifndef CLINGS_EXECUTION_H
 #define CLINGS_EXECUTION_H
 
-#include "../types/types.h"
-#include "../katas/katas.h"
+#include "types/types.h"
+#include "katas/katas.h"
 #define MAX_PATH_LENGTH 1024
 #define COMPILE_COMMAND "gcc -o /tmp/kata %s"
 #define RUN_COMMAND "/tmp/kata"
@@ -14,6 +14,6 @@
  * @param result_buffer String in which to write the result
  * @return The result status of the kata
  */
-kata_status run_kata(const kata_t kata, sized_string_t result_buffer);
+kata_status run_kata(kata_t kata, sized_string_t result_buffer);
 
 #endif //CLINGS_EXECUTION_H

--- a/src/execution/execution_test.c
+++ b/src/execution/execution_test.c
@@ -35,7 +35,7 @@ void tear_down(void) {
 static test_result should_get_file_not_found_if_file_does_not_exists(void);
 
 static test_result all_tests(void) {
-
+    should_get_file_not_found_if_file_does_not_exists();
     return EXIT_SUCCESS;
 }
 

--- a/src/execution/execution_test.c
+++ b/src/execution/execution_test.c
@@ -1,0 +1,45 @@
+
+// TODO refacto run_kata to take the I/O tools in param
+
+#include "stdlib.h"
+#include "stdio.h"
+#include "test_utils.h"
+#include "execution.h"
+
+#define BUFFER_SIZE 512
+
+static test_result all_tests(void);
+
+
+int main(void) {
+    const char * result = all_tests();
+    if(result == NULL) {
+        printf("ALL TESTS PASSED\n");
+    } else {
+        printf("%s\n", result);
+    }
+
+    return EXIT_SUCCESS;
+}
+
+sized_string_t buffer = {.str = NULL, .len = 0};
+
+void before_each(void) {
+    buffer = new_sized_string_of_length(BUFFER_SIZE);
+}
+
+void tear_down(void) {
+    free_sized_string(&buffer);
+}
+
+static test_result should_get_file_not_found_if_file_does_not_exists(void);
+
+static test_result all_tests(void) {
+
+    return EXIT_SUCCESS;
+}
+
+static test_result should_get_file_not_found_if_file_does_not_exists(void) {
+    return TEST_SUCCESS;
+}
+

--- a/src/katas/CMakeLists.txt
+++ b/src/katas/CMakeLists.txt
@@ -1,0 +1,11 @@
+project(katas C)
+
+add_library(katas katas.c)
+target_include_directories(types PUBLIC ..)
+
+add_executable(katas_test
+        katas_test.c
+        katas.c
+)
+
+add_test(NAME katas_test COMMAND katas_test)

--- a/src/katas/katas.c
+++ b/src/katas/katas.c
@@ -3,7 +3,7 @@
 
 
 void free_kata_list(kata_list_t *kata_list) {
-    if(kata_list->katas == NULL) return;
+    if (kata_list->katas == NULL) return;
     for (size_t i = 0; i < kata_list->len; i++) {
         free_kata(&kata_list->katas[i]);
     }
@@ -12,19 +12,22 @@ void free_kata_list(kata_list_t *kata_list) {
 }
 
 void free_kata(kata_t *kata) {
-    if(kata) {
+    if (kata) {
         free_sized_string(&kata->name);
         free_sized_string(&kata->path);
     }
 }
 
-void push_kata_in_list_with_realloc(kata_t kata, kata_list_t *list, reallocer r) {
-    if(!list->katas) {
+void push_kata_in_list_with_realloc(kata_t kata, kata_list_t *list, realloc_f realloc) {
+    if (!list->katas) {
         list->len = 0;
     }
 
-    kata_t * reallocated = (kata_t *) (*r)(list->katas, (list->len+1) * sizeof(kata_t));
-    if(reallocated == NULL) {
+    kata_t *reallocated = (*realloc)( // call the parameter function pointer realloc (see realloc_f)
+            list->katas,
+            (list->len + 1) * sizeof(kata_t)
+    );
+    if (reallocated == NULL) {
         return;
     }
     list->len++;

--- a/src/katas/katas.c
+++ b/src/katas/katas.c
@@ -8,6 +8,7 @@ void free_kata_list(kata_list_t *kata_list) {
         free_kata(&kata_list->katas[i]);
     }
     kata_list->katas = NULL;
+    kata_list->len = 0;
 }
 
 void free_kata(kata_t *kata) {
@@ -17,14 +18,16 @@ void free_kata(kata_t *kata) {
     }
 }
 
-void push_kata_in_list(kata_t kata, kata_list_t *list) {
-    list->len++;
-    kata_t * reallocated = (kata_t *) realloc(list->katas, list->len * sizeof(kata_t));
-    if(reallocated == NULL) {
-        fprintf(stderr, "Failed to allocate memory for kata list.");
-        free_kata_list(list);
-        exit(EXIT_FAILURE);
+void push_kata_in_list_with_realloc(kata_t kata, kata_list_t *list, reallocer r) {
+    if(!list->katas) {
+        list->len = 0;
     }
+
+    kata_t * reallocated = (kata_t *) (*r)(list->katas, (list->len+1) * sizeof(kata_t));
+    if(reallocated == NULL) {
+        return;
+    }
+    list->len++;
     list->katas = reallocated;
     list->katas[list->len - 1] = kata;
 }

--- a/src/katas/katas.h
+++ b/src/katas/katas.h
@@ -4,6 +4,7 @@
 #include "types/types.h"
 #include "stdbool.h"
 
+typedef void *(*reallocer)(void * ptr, size_t size);
 
 /**
  * @brief Represents a kata with name and path information.
@@ -41,7 +42,7 @@ typedef struct kata {
  *
  * @see kata_t
  * @see free_kata_list
- * @see push_kata_in_list
+ * @see push_kata_in_list_with_realloc
  */
 typedef struct kata_list {
     kata_t *katas;
@@ -114,7 +115,7 @@ void free_kata(kata_t *kata);
  * @param kata_list The `kata_list_t` structure to be freed.
  *
  * @see kata_list_t
- * @see push_kata_in_list
+ * @see push_kata_in_list_with_realloc
  */
 void free_kata_list(kata_list_t *kata_list);
 
@@ -131,7 +132,7 @@ void free_kata_list(kata_list_t *kata_list);
  * @code
  * kata_t my_kata =  ... ;
  * kata_list_t my_kata_list = ... ;
- * push_kata_in_list(my_kata, &my_kata_list);
+ * push_kata_in_list_with_realloc(my_kata, &my_kata_list);
  * // Now, `my_kata_list` contains the newly added kata.
  * @endcode
  *
@@ -142,6 +143,7 @@ void free_kata_list(kata_list_t *kata_list);
  * @see kata_list_t
  * @see free_kata_list
  */
-void push_kata_in_list(kata_t kata, kata_list_t *list);
+void push_kata_in_list_with_realloc(kata_t kata, kata_list_t *list, reallocer r);
+#define push_kata_in_list(kata, list) push_kata_in_list_with_realloc(kata, list, &realloc)
 
 #endif //CLINGS_KATAS_H

--- a/src/katas/katas.h
+++ b/src/katas/katas.h
@@ -4,7 +4,6 @@
 #include "types/types.h"
 #include "stdbool.h"
 
-typedef void *(*reallocer)(void * ptr, size_t size);
 
 /**
  * @brief Represents a kata with name and path information.
@@ -143,7 +142,7 @@ void free_kata_list(kata_list_t *kata_list);
  * @see kata_list_t
  * @see free_kata_list
  */
-void push_kata_in_list_with_realloc(kata_t kata, kata_list_t *list, reallocer r);
+void push_kata_in_list_with_realloc(kata_t kata, kata_list_t *list, realloc_f realloc);
 #define push_kata_in_list(kata, list) push_kata_in_list_with_realloc(kata, list, &realloc)
 
 #endif //CLINGS_KATAS_H

--- a/src/katas/katas_test.c
+++ b/src/katas/katas_test.c
@@ -1,0 +1,107 @@
+#include "stdlib.h"
+#include "stdio.h"
+#include "test_utils.h"
+#include "katas/katas.h"
+
+static test_result all_tests(void);
+
+int main(void) {
+    const char * result = all_tests();
+    if(result == NULL) {
+        printf("ALL TESTS PASSED\n");
+    } else {
+        printf("%s\n", result);
+    }
+
+    return EXIT_SUCCESS;
+}
+
+kata_list_t list = {.katas = NULL, .len = 0};
+#define new_kata (kata_t){.name = new_sized_string_from("new kata"), .path = new_sized_string_from("new"), .is_done = false }
+
+void before_each(void) {
+    list.len = 3;
+    list.katas = malloc(sizeof(kata_t) * list.len);
+    list.katas[0] = (kata_t) {.name = new_sized_string_from("first"), .path = new_sized_string_from("f"), .is_done = true };
+    list.katas[1] = (kata_t) {.name = new_sized_string_from("second"), .path = new_sized_string_from("s"), .is_done = false };
+    list.katas[2] = (kata_t) {.name = new_sized_string_from("third"), .path = new_sized_string_from("t"), .is_done = false };
+}
+
+void tear_down(void) {
+    free_kata_list(&list);
+}
+
+static test_result should_push_in_kata_list(void);
+static test_result push_in_null_kata_list_should_create_list_of_one_kata(void);
+static test_result push_in_null_kata_list_should_do_nothing_if_allocation_failed(void);
+static test_result free_kata_list_should_set_list_to_null_and_length_to_zero(void);
+static test_result free_kata_should_set_name_and_path_to_null(void);
+
+
+static test_result all_tests(void) {
+    run_test(should_push_in_kata_list);
+    run_test(push_in_null_kata_list_should_create_list_of_one_kata);
+    run_test(push_in_null_kata_list_should_do_nothing_if_allocation_failed);
+    run_test(free_kata_list_should_set_list_to_null_and_length_to_zero);
+    run_test(free_kata_should_set_name_and_path_to_null);
+
+    return EXIT_SUCCESS;
+}
+
+static test_result should_push_in_kata_list(void) {
+    push_kata_in_list(new_kata, &list);
+
+    assert_value_strict_equals_expected(list.len, 4);
+    assert_string_equals_expected("new kata", list.katas[3].name.str);
+    assert_string_equals_expected("new", list.katas[3].path.str);
+    assert_value_strict_equals_expected(list.katas[3].is_done, false);
+
+    return TEST_SUCCESS;
+}
+
+static test_result push_in_null_kata_list_should_create_list_of_one_kata(void) {
+    kata_list_t null_list = {.katas = NULL, .len = 3};
+
+    push_kata_in_list(new_kata, &null_list);
+
+    assert_value_strict_equals_expected(null_list.len, 1);
+    assert_string_equals_expected("new kata", null_list.katas[0].name.str);
+    assert_string_equals_expected("new", null_list.katas[0].path.str);
+    assert_value_strict_equals_expected(null_list.katas[0].is_done, false);
+
+    return TEST_SUCCESS;
+}
+
+void * failing_realloc(__attribute__((unused)) void * ptr, __attribute__((unused)) size_t size) {
+    return NULL;
+}
+
+static test_result push_in_null_kata_list_should_do_nothing_if_allocation_failed(void) {
+    push_kata_in_list_with_realloc(new_kata, &list, &failing_realloc);
+
+    assert_value_strict_equals_expected(list.len, 3);
+
+    return TEST_SUCCESS;
+}
+
+
+
+static test_result free_kata_list_should_set_list_to_null_and_length_to_zero(void) {
+    free_kata_list(&list);
+
+    assert_is_null(list.katas);
+    assert_value_strict_equals_expected(list.len, 0);
+
+    return TEST_SUCCESS;
+}
+
+static test_result free_kata_should_set_name_and_path_to_null(void) {
+    free_kata(&list.katas[0]);
+
+    assert_is_null(list.katas[0].name.str);
+    assert_is_null(list.katas[0].path.str);
+
+    return TEST_SUCCESS;
+}
+
+

--- a/src/result_handler/CMakeLists.txt
+++ b/src/result_handler/CMakeLists.txt
@@ -1,0 +1,4 @@
+project(result_handler C)
+
+add_library(result_handler result_handler.c)
+target_include_directories(execution PUBLIC ..)

--- a/src/result_handler/result_handler.h
+++ b/src/result_handler/result_handler.h
@@ -1,4 +1,4 @@
-#include "../types/types.h"
+#include "types/types.h"
 
 #ifndef CLINGS_RESULT_HANDLER_H
 #define CLINGS_RESULT_HANDLER_H

--- a/src/test_utils/CMakeLists.txt
+++ b/src/test_utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(clings_test_utils C)
+project(test_utils C)
 
-add_library(clings_test_utils INTERFACE)
-target_include_directories(clings_test_utils INTERFACE .)
+add_library(test_utils INTERFACE)
+target_include_directories(test_utils INTERFACE .)

--- a/src/test_utils/CMakeLists.txt
+++ b/src/test_utils/CMakeLists.txt
@@ -1,0 +1,4 @@
+project(clings_test_utils C)
+
+add_library(clings_test_utils INTERFACE)
+target_include_directories(clings_test_utils INTERFACE .)

--- a/src/test_utils/clings_test_utils.h
+++ b/src/test_utils/clings_test_utils.h
@@ -1,0 +1,21 @@
+#ifndef CLINGS_CLINGS_TEST_UTILS_H
+#define CLINGS_CLINGS_TEST_UTILS_H
+
+#include "stdlib.h"
+
+
+#define stringify(x) #x
+#define error_output_string(file, line, message) file ":" stringify(line) ": error: " message
+
+#define run_test(test) before_each(); { const char * msg = test(); if (msg) return msg; } tear_down()
+#define cling_assert(test, message) if (!(test)) return error_output_string(__FILE__, __LINE__, message)
+#define assert_string_equals_expected(str, expected) cling_assert(strcmp(str, expected) == 0, #str " should be equals to [" #expected "].")
+#define assert_value_strict_equals_expected(value, expected) cling_assert(value == expected, #value " should be strictly equals to [" #expected "].")
+#define assert_values_are_different(value1, value2) cling_assert(value1 != value2, #value1 " should NOT be equals to [" #value2 "].")
+#define assert_is_null(value) cling_assert(value == NULL, #value " should be NULL.")
+#define assert_is_not_null(value) cling_assert(value != NULL, #value " should NOT be NULL.")
+
+#define TEST_SUCCESS EXIT_SUCCESS
+typedef const char * test_result;
+
+#endif //CLINGS_CLINGS_TEST_UTILS_H

--- a/src/test_utils/test_utils.h
+++ b/src/test_utils/test_utils.h
@@ -2,6 +2,7 @@
 #define CLINGS_TEST_UTILS_H
 
 #include "stdlib.h"
+#include "string.h"
 
 
 #define stringify(x) #x

--- a/src/test_utils/test_utils.h
+++ b/src/test_utils/test_utils.h
@@ -1,5 +1,5 @@
-#ifndef CLINGS_CLINGS_TEST_UTILS_H
-#define CLINGS_CLINGS_TEST_UTILS_H
+#ifndef CLINGS_TEST_UTILS_H
+#define CLINGS_TEST_UTILS_H
 
 #include "stdlib.h"
 
@@ -18,4 +18,4 @@
 #define TEST_SUCCESS EXIT_SUCCESS
 typedef const char * test_result;
 
-#endif //CLINGS_CLINGS_TEST_UTILS_H
+#endif //CLINGS_TEST_UTILS_H

--- a/src/types/CMakeLists.txt
+++ b/src/types/CMakeLists.txt
@@ -1,0 +1,13 @@
+project(types C)
+
+
+add_library(types sized_string.c)
+
+enable_testing()
+add_executable(sized_string_test
+        sized_string_test.c
+        sized_string.c
+)
+
+
+add_test(NAME sized_string_test COMMAND sized_string_test)

--- a/src/types/CMakeLists.txt
+++ b/src/types/CMakeLists.txt
@@ -1,13 +1,11 @@
 project(types C)
 
-
 add_library(types sized_string.c)
+target_include_directories(types PUBLIC ..)
 
-enable_testing()
 add_executable(sized_string_test
         sized_string_test.c
         sized_string.c
 )
-
 
 add_test(NAME sized_string_test COMMAND sized_string_test)

--- a/src/types/sized_string.c
+++ b/src/types/sized_string.c
@@ -15,25 +15,38 @@ sized_string_t new_sized_string_of_length(size_t len) {
     return string;
 }
 
+sized_string_t new_sized_string_from_str_of_length(char *str, size_t len) {
+    if(!str) {
+        return new_sized_string_of_length(0);
+    }
+    sized_string_t string = new_sized_string_of_length(len);
+    if (!string.str) {
+        return string;
+    }
+    strncpy(string.str, str, len);
+    string.str[len] = '\0';
+    return string;
+}
+
 sized_string_t new_sized_string_from(char *string) {
     if (!string) {
         return new_sized_string_of_length(0);
     }
-    return copy_str_to_sized_string(
+    return new_sized_string_from_str_of_length(
             string,
             strlen(string)
     );
 }
 
 sized_string_t clone_sized_string(sized_string_t string) {
-    return copy_str_to_sized_string(string.str, string.len);
+    return new_sized_string_from_str_of_length(string.str, string.len);
 }
 
 sized_string_t concat_two_sized_string(sized_string_t first, sized_string_t second) {
-    if(first.len == 0) {
+    if (!first.str || first.len == 0) {
         return clone_sized_string(second);
     }
-    if(second.len == 0) {
+    if (!second.str || second.len == 0) {
         return clone_sized_string(first);
     }
     sized_string_t string = new_sized_string_of_length(first.len + second.len);
@@ -50,12 +63,3 @@ void free_sized_string(sized_string_t *string) {
     string->len = 0;
 }
 
-sized_string_t copy_str_to_sized_string(char *str, size_t len) {
-    sized_string_t string = new_sized_string_of_length(len);
-    if (!string.str) {
-        return string;
-    }
-    strncpy(string.str, str, len);
-    string.str[len] = '\0';
-    return string;
-}

--- a/src/types/sized_string.c
+++ b/src/types/sized_string.c
@@ -1,9 +1,10 @@
 #include <string.h>
 #include "types.h"
 
-sized_string_t new_sized_string_of_length_with_calloc(size_t len, callocer c) {
+sized_string_t new_sized_string_of_length_with_calloc(size_t len, calloc_f calloc) {
     sized_string_t string;
-    string.str = (char *) (*c)(
+
+    string.str = (char *) (*calloc)( // call the parameter function pointer calloc (see calloc_f)
             len + 1, // including the terminating null character '\0'.
             sizeof(char)
             );

--- a/src/types/sized_string.c
+++ b/src/types/sized_string.c
@@ -1,9 +1,9 @@
 #include <string.h>
 #include "types.h"
 
-sized_string_t new_sized_string_of_length(size_t len) {
+sized_string_t new_sized_string_of_length_with_calloc(size_t len, callocer c) {
     sized_string_t string;
-    string.str = (char *) calloc(
+    string.str = (char *) (*c)(
             len + 1, // including the terminating null character '\0'.
             sizeof(char)
             );

--- a/src/types/sized_string_test.c
+++ b/src/types/sized_string_test.c
@@ -1,17 +1,7 @@
 #include "types.h"
 #include "string.h"
 #include "stdio.h"
-
-#define stringify(x) #x
-#define error_output_string(file, line, message) file ":" stringify(line) ": error: " message
-
-#define run_test(test) before_each(); { const char * msg = test(); if (msg) return msg; } tear_down()
-#define cling_assert(test, message) if (!(test)) return error_output_string(__FILE__, __LINE__, message)
-#define assert_string_equals_expected(str, expected) cling_assert(strcmp(str, expected) == 0, #str " should be equals to [" #expected "].")
-#define assert_value_strict_equals_expected(value, expected) cling_assert(value == expected, #value " should be strictly equals to [" #expected "].")
-#define assert_values_are_different(value1, value2) cling_assert(value1 != value2, #value1 " should NOT be equals to [" #value2 "].")
-#define assert_is_null(value) cling_assert(value == NULL, #value " should be NULL.")
-#define assert_is_not_null(value) cling_assert(value != NULL, #value " should NOT be NULL.")
+#include "clings_test_utils.h"
 
 
 static const char * all_tests(void);
@@ -35,26 +25,26 @@ void tear_down(void) {
     free_sized_string(&string);
 }
 
-static const char * should_create_new_sized_string_of_length(void);
-static const char * should_create_new_sized_string_of_length_zero(void);
-static const char * should_get_null_string_if_memory_allocation_fails(void);
-static const char * should_create_new_sized_string_from_existing_string(void);
-static const char * should_create_new_sized_string_from_empty_string(void);
-static const char * should_create_new_sized_string_from_NULL(void);
-static const char * should_clone_string(void);
-static const char * cloned_sized_string_should_have_different_memory_address(void);
-static const char * clone_NULL_should_create_empty_string(void);
-static const char * should_concat_two_strings(void);
-static const char * should_concat_with_empty_string(void);
-static const char * should_concat_with_null_string(void);
-static const char * free_sized_string_should_set_pointer_to_NULL_and_length_to_zero(void);
-static const char * free_NULL_sized_string_should_do_nothing(void);
-static const char * should_create_new_sized_string_from_str_with_length(void);
-static const char * create_new_sized_string_from_str_with_more_length_than_enough_should_fill_with_terminating_char(void);
-static const char * create_new_sized_string_from_str_with_not_enough_should_truncate_string(void);
-static const char * create_new_sized_string_from_NULL_should_create_empty_string(void);
+static test_result should_create_new_sized_string_of_length(void);
+static test_result should_create_new_sized_string_of_length_zero(void);
+static test_result should_get_null_string_if_memory_allocation_fails(void);
+static test_result should_create_new_sized_string_from_existing_string(void);
+static test_result should_create_new_sized_string_from_empty_string(void);
+static test_result should_create_new_sized_string_from_NULL(void);
+static test_result should_clone_string(void);
+static test_result cloned_sized_string_should_have_different_memory_address(void);
+static test_result clone_NULL_should_create_empty_string(void);
+static test_result should_concat_two_strings(void);
+static test_result should_concat_with_empty_string(void);
+static test_result should_concat_with_null_string(void);
+static test_result free_sized_string_should_set_pointer_to_NULL_and_length_to_zero(void);
+static test_result free_NULL_sized_string_should_do_nothing(void);
+static test_result should_create_new_sized_string_from_str_with_length(void);
+static test_result create_new_sized_string_from_str_with_more_length_than_enough_should_fill_with_terminating_char(void);
+static test_result create_new_sized_string_from_str_with_not_enough_should_truncate_string(void);
+static test_result create_new_sized_string_from_NULL_should_create_empty_string(void);
 
-static const char * all_tests(void) {
+static test_result all_tests(void) {
     run_test(should_create_new_sized_string_of_length);
     run_test(should_create_new_sized_string_of_length_zero);
     run_test(should_get_null_string_if_memory_allocation_fails);
@@ -77,7 +67,7 @@ static const char * all_tests(void) {
 }
 
 
-static const char * should_create_new_sized_string_of_length(void) {
+static test_result should_create_new_sized_string_of_length(void) {
     string = new_sized_string_of_length(5);
     assert_is_not_null(string.str);
     assert_value_strict_equals_expected(string.len, 5);
@@ -88,64 +78,64 @@ static const char * should_create_new_sized_string_of_length(void) {
     // null terminating char at the end
     assert_value_strict_equals_expected(string.str[5], '\0');
 
-    return EXIT_SUCCESS;
+    return TEST_SUCCESS;
 }
 
-static const char * should_create_new_sized_string_of_length_zero(void) {
+static test_result should_create_new_sized_string_of_length_zero(void) {
     string = new_sized_string_of_length(0);
     assert_is_not_null(string.str);
     assert_value_strict_equals_expected(string.len, 0);
     assert_value_strict_equals_expected(string.str[0], '\0');
 
-    return EXIT_SUCCESS;
+    return TEST_SUCCESS;
 }
 
 void * failing_calloc(__attribute__((unused)) size_t count, __attribute__((unused)) size_t size) {
     return NULL;
 }
 
-static const char * should_get_null_string_if_memory_allocation_fails(void) {
+static test_result should_get_null_string_if_memory_allocation_fails(void) {
     string = new_sized_string_of_length_with_calloc(5, &failing_calloc);
 
     assert_is_null(string.str);
     assert_value_strict_equals_expected(string.len, 0);
 
-    return EXIT_SUCCESS;
+    return TEST_SUCCESS;
 }
 
-static const char * should_create_new_sized_string_from_existing_string(void) {
+static test_result should_create_new_sized_string_from_existing_string(void) {
     string = new_sized_string_from("clings");
     assert_is_not_null(string.str);
     assert_value_strict_equals_expected(string.len, 6);
     assert_string_equals_expected(string.str, "clings");
 
-    return EXIT_SUCCESS;
+    return TEST_SUCCESS;
 }
 
 // test length limit ? (currently no limit)
 
-static const char * should_create_new_sized_string_from_empty_string(void) {
+static test_result should_create_new_sized_string_from_empty_string(void) {
     string = new_sized_string_from("");
     assert_is_not_null(string.str);
     assert_value_strict_equals_expected(string.len, 0);
     assert_string_equals_expected(string.str, "");
     assert_value_strict_equals_expected(string.str[0], '\0');
 
-    return EXIT_SUCCESS;
+    return TEST_SUCCESS;
 }
 
 
-static const char * should_create_new_sized_string_from_NULL(void) {
+static test_result should_create_new_sized_string_from_NULL(void) {
     string = new_sized_string_from(NULL);
     assert_is_not_null(string.str);
     assert_value_strict_equals_expected(string.len, 0);
     assert_string_equals_expected(string.str, "");
     assert_value_strict_equals_expected(string.str[0], '\0');
 
-    return EXIT_SUCCESS;
+    return TEST_SUCCESS;
 }
 
-static const char * should_clone_string(void) {
+static test_result should_clone_string(void) {
     sized_string_t original = new_sized_string_from("clings");
     sized_string_t clone = clone_sized_string(original);
 
@@ -157,10 +147,10 @@ static const char * should_clone_string(void) {
     free_sized_string(&original);
     free_sized_string(&clone);
 
-    return EXIT_SUCCESS;
+    return TEST_SUCCESS;
 }
 
-static const char * cloned_sized_string_should_have_different_memory_address(void) {
+static test_result cloned_sized_string_should_have_different_memory_address(void) {
     sized_string_t original = new_sized_string_from("clings");
     sized_string_t clone = clone_sized_string(original);
 
@@ -169,10 +159,10 @@ static const char * cloned_sized_string_should_have_different_memory_address(voi
     free_sized_string(&original);
     free_sized_string(&clone);
 
-    return EXIT_SUCCESS;
+    return TEST_SUCCESS;
 }
 
-static const char * clone_NULL_should_create_empty_string(void) {
+static test_result clone_NULL_should_create_empty_string(void) {
     sized_string_t original = new_sized_string_from(NULL);
     sized_string_t clone = clone_sized_string(original);
 
@@ -183,11 +173,11 @@ static const char * clone_NULL_should_create_empty_string(void) {
     free_sized_string(&original);
     free_sized_string(&clone);
 
-    return EXIT_SUCCESS;
+    return TEST_SUCCESS;
 }
 
 
-static const char * should_concat_two_strings(void) {
+static test_result should_concat_two_strings(void) {
     sized_string_t first = new_sized_string_from("Hello ");
     sized_string_t second = new_sized_string_from("world!");
     sized_string_t concat = concat_two_sized_string(first, second);
@@ -200,10 +190,10 @@ static const char * should_concat_two_strings(void) {
     free_sized_string(&second);
     free_sized_string(&concat);
 
-    return EXIT_SUCCESS;
+    return TEST_SUCCESS;
 }
 
-static const char * should_concat_with_empty_string(void) {
+static test_result should_concat_with_empty_string(void) {
     sized_string_t first = new_sized_string_from("Hello ");
     sized_string_t second = new_sized_string_from("");
     sized_string_t concat = concat_two_sized_string(first, second);
@@ -228,10 +218,10 @@ static const char * should_concat_with_empty_string(void) {
     free_sized_string(&second);
     free_sized_string(&concat);
 
-    return EXIT_SUCCESS;
+    return TEST_SUCCESS;
 }
 
-static const char * should_concat_with_null_string(void) {
+static test_result should_concat_with_null_string(void) {
     sized_string_t first = new_sized_string_from("Hello ");
     sized_string_t second = (sized_string_t) {.str = NULL, .len = 2};
     sized_string_t concat = concat_two_sized_string(first, second);
@@ -257,38 +247,38 @@ static const char * should_concat_with_null_string(void) {
     free_sized_string(&second);
     free_sized_string(&concat);
 
-    return EXIT_SUCCESS;
+    return TEST_SUCCESS;
 }
 
-static const char * free_sized_string_should_set_pointer_to_NULL_and_length_to_zero(void) {
+static test_result free_sized_string_should_set_pointer_to_NULL_and_length_to_zero(void) {
     string = new_sized_string_from("clings");
     free_sized_string(&string);
     assert_is_null(string.str);
     assert_value_strict_equals_expected(string.len, 0);
 
-    return EXIT_SUCCESS;
+    return TEST_SUCCESS;
 }
 
-static const char * free_NULL_sized_string_should_do_nothing(void) {
+static test_result free_NULL_sized_string_should_do_nothing(void) {
     string = (sized_string_t) {.str = NULL, .len = 0};
     free_sized_string(&string);
     assert_is_null(string.str);
 
-    return EXIT_SUCCESS;
+    return TEST_SUCCESS;
 }
 
 
-static const char * should_create_new_sized_string_from_str_with_length(void) {
+static test_result should_create_new_sized_string_from_str_with_length(void) {
     string = new_sized_string_from_str_of_length("clings", 6);
 
     assert_is_not_null(string.str);
     assert_value_strict_equals_expected(string.len, 6);
     assert_string_equals_expected(string.str, "clings");
 
-    return EXIT_SUCCESS;
+    return TEST_SUCCESS;
 }
 
-static const char * create_new_sized_string_from_str_with_more_length_than_enough_should_fill_with_terminating_char(void) {
+static test_result create_new_sized_string_from_str_with_more_length_than_enough_should_fill_with_terminating_char(void) {
     string = new_sized_string_from_str_of_length("abc", 6);
 
     assert_is_not_null(string.str);
@@ -298,25 +288,25 @@ static const char * create_new_sized_string_from_str_with_more_length_than_enoug
         assert_value_strict_equals_expected(string.str[i], '\0');
     }
 
-    return EXIT_SUCCESS;
+    return TEST_SUCCESS;
 }
 
-static const char * create_new_sized_string_from_str_with_not_enough_should_truncate_string(void) {
+static test_result create_new_sized_string_from_str_with_not_enough_should_truncate_string(void) {
     string = new_sized_string_from_str_of_length("abcdef", 3);
 
     assert_is_not_null(string.str);
     assert_value_strict_equals_expected(string.len, 3);
     assert_string_equals_expected(string.str, "abc");
 
-    return EXIT_SUCCESS;
+    return TEST_SUCCESS;
 }
 
-static const char * create_new_sized_string_from_NULL_should_create_empty_string(void) {
+static test_result create_new_sized_string_from_NULL_should_create_empty_string(void) {
     string = new_sized_string_from_str_of_length(NULL, 3);
 
     assert_is_not_null(string.str);
     assert_value_strict_equals_expected(string.len, 0);
     assert_string_equals_expected(string.str, "");
 
-    return EXIT_SUCCESS;
+    return TEST_SUCCESS;
 }

--- a/src/types/sized_string_test.c
+++ b/src/types/sized_string_test.c
@@ -1,7 +1,7 @@
 #include "types.h"
 #include "string.h"
 #include "stdio.h"
-#include "clings_test_utils.h"
+#include "test_utils.h"
 
 
 static const char * all_tests(void);

--- a/src/types/sized_string_test.c
+++ b/src/types/sized_string_test.c
@@ -2,13 +2,16 @@
 #include "string.h"
 #include "stdio.h"
 
+#define stringify(x) #x
+#define error_output_string(file, line, message) file ":" stringify(line) ": error: " message
+
 #define run_test(test) before_each(); { const char * msg = test(); if (msg) return msg; } tear_down()
-#define cling_assert(test, message) if (!(test)) return message
-#define assert_string_equals_expected(str, expected) cling_assert(strcmp(str, expected) == 0, "strings should be equals.")
-#define assert_value_strict_equals_expected(value, expected) cling_assert(value == expected, "value should be strictly equals.")
-#define assert_values_are_different(value1, value2) cling_assert(value1 != value2, "values should be different.")
-#define assert_is_null(value) cling_assert(value == NULL, "value should be NULL.")
-#define assert_is_not_null(value) cling_assert(value != NULL, "value should not be NULL.")
+#define cling_assert(test, message) if (!(test)) return error_output_string(__FILE__, __LINE__, message)
+#define assert_string_equals_expected(str, expected) cling_assert(strcmp(str, expected) == 0, #str " should be equals to [" #expected "].")
+#define assert_value_strict_equals_expected(value, expected) cling_assert(value == expected, #value " should be strictly equals to [" #expected "].")
+#define assert_values_are_different(value1, value2) cling_assert(value1 != value2, #value1 " should NOT be equals to [" #value2 "].")
+#define assert_is_null(value) cling_assert(value == NULL, #value " should be NULL.")
+#define assert_is_not_null(value) cling_assert(value != NULL, #value " should NOT be NULL.")
 
 
 static const char * all_tests(void);

--- a/src/types/sized_string_test.c
+++ b/src/types/sized_string_test.c
@@ -4,7 +4,7 @@
 #include "test_utils.h"
 
 
-static const char * all_tests(void);
+static test_result all_tests(void);
 
 int main(void) {
     const char * result = all_tests();
@@ -30,19 +30,19 @@ static test_result should_create_new_sized_string_of_length_zero(void);
 static test_result should_get_null_string_if_memory_allocation_fails(void);
 static test_result should_create_new_sized_string_from_existing_string(void);
 static test_result should_create_new_sized_string_from_empty_string(void);
-static test_result should_create_new_sized_string_from_NULL(void);
+static test_result should_create_new_sized_string_from_null(void);
 static test_result should_clone_string(void);
 static test_result cloned_sized_string_should_have_different_memory_address(void);
-static test_result clone_NULL_should_create_empty_string(void);
+static test_result clone_null_should_create_empty_string(void);
 static test_result should_concat_two_strings(void);
 static test_result should_concat_with_empty_string(void);
 static test_result should_concat_with_null_string(void);
-static test_result free_sized_string_should_set_pointer_to_NULL_and_length_to_zero(void);
-static test_result free_NULL_sized_string_should_do_nothing(void);
+static test_result free_sized_string_should_set_pointer_to_null_and_length_to_zero(void);
+static test_result free_null_sized_string_should_do_nothing(void);
 static test_result should_create_new_sized_string_from_str_with_length(void);
 static test_result create_new_sized_string_from_str_with_more_length_than_enough_should_fill_with_terminating_char(void);
 static test_result create_new_sized_string_from_str_with_not_enough_should_truncate_string(void);
-static test_result create_new_sized_string_from_NULL_should_create_empty_string(void);
+static test_result create_new_sized_string_from_null_should_create_empty_string(void);
 
 static test_result all_tests(void) {
     run_test(should_create_new_sized_string_of_length);
@@ -50,19 +50,19 @@ static test_result all_tests(void) {
     run_test(should_get_null_string_if_memory_allocation_fails);
     run_test(should_create_new_sized_string_from_existing_string);
     run_test(should_create_new_sized_string_from_empty_string);
-    run_test(should_create_new_sized_string_from_NULL);
+    run_test(should_create_new_sized_string_from_null);
     run_test(should_clone_string);
     run_test(cloned_sized_string_should_have_different_memory_address);
-    run_test(clone_NULL_should_create_empty_string);
+    run_test(clone_null_should_create_empty_string);
     run_test(should_concat_two_strings);
     run_test(should_concat_with_empty_string);
     run_test(should_concat_with_null_string);
-    run_test(free_sized_string_should_set_pointer_to_NULL_and_length_to_zero);
-    run_test(free_NULL_sized_string_should_do_nothing);
+    run_test(free_sized_string_should_set_pointer_to_null_and_length_to_zero);
+    run_test(free_null_sized_string_should_do_nothing);
     run_test(should_create_new_sized_string_from_str_with_length);
     run_test(create_new_sized_string_from_str_with_more_length_than_enough_should_fill_with_terminating_char);
     run_test(create_new_sized_string_from_str_with_not_enough_should_truncate_string);
-    run_test(create_new_sized_string_from_NULL_should_create_empty_string);
+    run_test(create_new_sized_string_from_null_should_create_empty_string);
     return NULL;
 }
 
@@ -125,7 +125,7 @@ static test_result should_create_new_sized_string_from_empty_string(void) {
 }
 
 
-static test_result should_create_new_sized_string_from_NULL(void) {
+static test_result should_create_new_sized_string_from_null(void) {
     string = new_sized_string_from(NULL);
     assert_is_not_null(string.str);
     assert_value_strict_equals_expected(string.len, 0);
@@ -162,7 +162,7 @@ static test_result cloned_sized_string_should_have_different_memory_address(void
     return TEST_SUCCESS;
 }
 
-static test_result clone_NULL_should_create_empty_string(void) {
+static test_result clone_null_should_create_empty_string(void) {
     sized_string_t original = new_sized_string_from(NULL);
     sized_string_t clone = clone_sized_string(original);
 
@@ -250,7 +250,7 @@ static test_result should_concat_with_null_string(void) {
     return TEST_SUCCESS;
 }
 
-static test_result free_sized_string_should_set_pointer_to_NULL_and_length_to_zero(void) {
+static test_result free_sized_string_should_set_pointer_to_null_and_length_to_zero(void) {
     string = new_sized_string_from("clings");
     free_sized_string(&string);
     assert_is_null(string.str);
@@ -259,7 +259,7 @@ static test_result free_sized_string_should_set_pointer_to_NULL_and_length_to_ze
     return TEST_SUCCESS;
 }
 
-static test_result free_NULL_sized_string_should_do_nothing(void) {
+static test_result free_null_sized_string_should_do_nothing(void) {
     string = (sized_string_t) {.str = NULL, .len = 0};
     free_sized_string(&string);
     assert_is_null(string.str);
@@ -301,7 +301,7 @@ static test_result create_new_sized_string_from_str_with_not_enough_should_trunc
     return TEST_SUCCESS;
 }
 
-static test_result create_new_sized_string_from_NULL_should_create_empty_string(void) {
+static test_result create_new_sized_string_from_null_should_create_empty_string(void) {
     string = new_sized_string_from_str_of_length(NULL, 3);
 
     assert_is_not_null(string.str);

--- a/src/types/types.h
+++ b/src/types/types.h
@@ -35,7 +35,39 @@ typedef struct sized_string_t {
     size_t len;
 } sized_string_t;
 
-typedef void *(*callocer)(size_t count, size_t size);
+
+/**
+ * Typedef for a function pointer implementing the behavior of the calloc function.
+ *
+ * Functions matching this typedef are expected to allocate memory for an array
+ * of 'count' objects, each 'size' bytes in size. The memory is initialized to zero.
+ * The function returns a pointer to the allocated memory if the allocation is successful.
+ * If the allocation fails, the function returns NULL and sets the errno to ENOMEM.
+ *
+ * The main use of this typedef is to mock the calloc function for testing.
+ *
+ * @param count Number of elements to allocate memory for.
+ * @param size Size of each element in bytes.
+ * @return Pointer to the allocated memory block if successful; otherwise, NULL.
+ */
+typedef void *(*calloc_f)(size_t count, size_t size);
+
+/**
+ * Typedef for a function pointer implementing the behavior of the realloc function.
+ *
+ * Functions matching this typedef are expected to reallocate memory as specified by realloc,
+ * possibly moving it to a new location. The function returns a pointer to the newly
+ * allocated memory if the reallocation is successful. If the reallocation fails,
+ * the function returns NULL and sets the errno to ENOMEM.
+ *
+ * The main use of this typedef is to mock the realloc function for testing.
+ *
+ * @param ptr Pointer to the memory block previously allocated with malloc, calloc, or realloc.
+ * @param size New size in bytes for the memory block.
+ * @return Pointer to the reallocated memory block if successful; otherwise, NULL.
+ */
+typedef void *(*realloc_f)(void * ptr, size_t size);
+
 
 /**
  * @brief Creates a new sized_string_t with the specified length.
@@ -50,7 +82,7 @@ typedef void *(*callocer)(size_t count, size_t size);
  * @param len The length of the string buffer to allocate
  * @return A sized_string_t with allocated string and specified length
  */
-sized_string_t new_sized_string_of_length_with_calloc(size_t len, callocer c);
+sized_string_t new_sized_string_of_length_with_calloc(size_t len, calloc_f calloc);
 #define new_sized_string_of_length(len) new_sized_string_of_length_with_calloc(len, &calloc)
 
 /**

--- a/src/types/types.h
+++ b/src/types/types.h
@@ -1,8 +1,7 @@
 #ifndef CLINGS_TYPES_H
 #define CLINGS_TYPES_H
 
-#include <stddef.h>
-#include <stdlib.h>
+#include "stdlib.h"
 
 typedef enum {
     KATA_SUCCESS, // the kata is done
@@ -27,7 +26,7 @@ typedef enum {
  * // Now, `my_string` represents a string with content "Hello, World!" and length 13.
  * @endcode
  *
- * @see copy_str_to_sized_string
+ * @see new_sized_string_from_str_of_length
  * @see new_sized_string_of_length
  * @see empty_sized_string
  */
@@ -140,7 +139,7 @@ sized_string_t clone_sized_string(sized_string_t string);
 sized_string_t concat_two_sized_string(sized_string_t first, sized_string_t second);
 
 /**
- * @brief Copies a given string to a sized string.
+ * @brief Create new sized string from a given string(char*) with specified length.
  *
  * This function creates a new `sized_string_t` structure by copying the
  * specified string (char *) with the given length (NOT including
@@ -155,17 +154,17 @@ sized_string_t concat_two_sized_string(sized_string_t first, sized_string_t seco
  * Examples Usage:
  * @code
  * char * str = "Hello";
- * sized_string_t hello_str = copy_str_to_sized_string(str, strlen(str));
+ * sized_string_t hello_str = new_sized_string_from_str_of_length(str, strlen(str));
  * // Now, `hello_str` contains the copied string "Hello\0" with length 5.
  * @endcode
  *
  * @code
- * copy_str_to_sized_string("abcdef", 3);
+ * new_sized_string_from_str_of_length("abcdef", 3);
  * // Will return -> {str: "abc\0", len: 3}
  * @endcode
  *
  * @code
- * copy_str_to_sized_string("abc", 5);
+ * new_sized_string_from_str_of_length("abc", 5);
  * // Will return -> {str: "abc\0\0\0", len: 5}
  * @endcode
  *
@@ -176,7 +175,7 @@ sized_string_t concat_two_sized_string(sized_string_t first, sized_string_t seco
  *
  * @see sized_string_t
  */
-sized_string_t copy_str_to_sized_string(char * str, size_t len);
+sized_string_t new_sized_string_from_str_of_length(char * str, size_t len);
 
 /**
  * @brief Frees the memory allocated for a sized_string_t

--- a/src/types/types.h
+++ b/src/types/types.h
@@ -35,6 +35,8 @@ typedef struct sized_string_t {
     size_t len;
 } sized_string_t;
 
+typedef void *(*callocer)(size_t count, size_t size);
+
 /**
  * @brief Creates a new sized_string_t with the specified length.
  * The string is filled of null character '\0';
@@ -48,7 +50,8 @@ typedef struct sized_string_t {
  * @param len The length of the string buffer to allocate
  * @return A sized_string_t with allocated string and specified length
  */
-sized_string_t new_sized_string_of_length(size_t len);
+sized_string_t new_sized_string_of_length_with_calloc(size_t len, callocer c);
+#define new_sized_string_of_length(len) new_sized_string_of_length_with_calloc(len, &calloc)
 
 /**
  * @brief Creates a new `sized_string_t` object from a null-terminated string.


### PR DESCRIPTION
Create tiny macros test-lib inspired by minunit.
Add tests for sized_string and katas.
Create a tree of cmakelist, each component is a library which refer to the test(s).
Change the readme : remove vcpck ref and add the testing section.
Refactoring allocation functions to take the allocator in param, with macros to define default allocator. This way we can test on allocation failure by passing our mock allocator.

Create an empty test for the executor because I think we should change the implementation to be more resilient on system call failures before/during the creation of the tests.
I did not create tests for the handler because it is simply some printf in it.